### PR TITLE
biorhythm: added compability calculation

### DIFF
--- a/biorhythms.py
+++ b/biorhythms.py
@@ -1,0 +1,33 @@
+from datetime import datetime, date
+
+CHAKRAS = dict(muladhara = 23.6884, 
+               swadihshthana = 28.426125,
+               manipura = 33.163812,
+               anahatha = 37.901499,
+               vishuddha = 42.6392,
+               ajna = 47.3769,
+               sahasrara = 52.1146)
+
+#PHASE_DIFFERENCE = (200 / p) * Abs(Mod(d, p) - p / 2)
+
+def bday_delta(bdate1, bdate2):
+    date_user1 = datetime.strptime(bdate1, '%d.%m.%Y')
+    date_user2 = datetime.strptime(bdate2, '%d.%m.%Y')
+    days_user1 = datetime.now() - date_user1
+    days_user2 = datetime.now() - date_user2
+    delta = abs(days_user1 - days_user2).days
+    return delta
+
+def phase_diff (chakra, delta):
+    compability = (200 / chakra) * abs(delta % chakra - chakra / 2)
+    return round(compability)
+
+def chakras_compability(delta):
+    compability = dict()
+    for chakra, value in CHAKRAS.items():
+        compability[chakra] = phase_diff(value, delta)
+    return compability
+
+#delta = bday_delta('17.11.1998', '7.10.1998')
+#print(chakras_compability(delta))
+#{'muladhara': 46, 'swadihshthana': 12, 'manipura': 53, 'anahatha': 84, 'vishuddha': 92, 'ajna': 73, 'sahasrara': 57}

--- a/biorythms.py
+++ b/biorythms.py
@@ -1,0 +1,33 @@
+from datetime import datetime, date
+
+CHAKRAS = dict(muladhara = 23.6884, 
+               swadihshthana = 28.426125,
+               manipura = 33.163812,
+               anahatha = 37.901499,
+               vishuddha = 42.6392,
+               ajna = 47.3769,
+               sahasrara = 52.1146)
+
+#PHASE_DIFFERENCE = (200 / p) * Abs(Mod(d, p) - p / 2)
+
+def bday_delta(bdate1, bdate2):
+    date_user1 = datetime.strptime(bdate1, '%d.%m.%Y')
+    date_user2 = datetime.strptime(bdate2, '%d.%m.%Y')
+    days_user1 = datetime.now() - date_user1
+    days_user2 = datetime.now() - date_user2
+    delta = abs(days_user1 - days_user2).days
+    return delta
+
+def phase_diff (chakra, delta):
+    compability = (200 / chakra) * abs(delta % chakra - chakra / 2)
+    return round(compability)
+
+def chakras_compability(delta):
+    compability = dict()
+    for chakra, value in CHAKRAS.items():
+        compability[chakra] = phase_diff(value, delta)
+    return compability
+
+#delta = bday_delta('17.11.1998', '7.10.1998')
+#print(chakras_compability(delta))
+#{'muladhara': 46, 'swadihshthana': 12, 'manipura': 53, 'anahatha': 84, 'vishuddha': 92, 'ajna': 73, 'sahasrara': 57}


### PR DESCRIPTION
Phase difference is the original compatibility method used in Palm Biorhythms. It works as follows, when two person's cycles are in phase their compatibility is 100% when they are out of phase their compatilibility is 0%. Values in between vary uniformly between 100% and 0%.

This definition produces a formula that varies according to the phase difference between two people's biorhythm cycles:

Compatibility % = (200 / p) * Abs(Mod(d, p) - p / 2)

Where:
d | Number of days between the birth dates of the two people being compared
p | The  period of a biorhythm cycle in days. The physical cycle is 23 days, the  emotional is 28 days and the intellectual is 33 days.
Abs() | The absolute value of the number in brackets. The absolute value is the number without its sign. Therefore Abs(-2) is 2.
Mod(a, b) | The remainder after dividing a by b.




